### PR TITLE
feat(layer): port first docus upstream bundle

### DIFF
--- a/packages/layer/app/pages/[...slug].vue
+++ b/packages/layer/app/pages/[...slug].vue
@@ -63,6 +63,11 @@ useSeoMeta({
   title: page.value?.title,
   description: page.value?.description,
 })
+
+// Register raw markdown variant so static builds expose /raw/*.md for AI agents
+if (import.meta.server) {
+  prerenderRoutes(`/raw${route.path}.md`)
+}
 </script>
 
 <template>

--- a/packages/layer/app/pages/[...slug].vue
+++ b/packages/layer/app/pages/[...slug].vue
@@ -64,8 +64,10 @@ useSeoMeta({
   description: page.value?.description,
 })
 
-// Register raw markdown variant so static builds expose /raw/*.md for AI agents
-if (import.meta.server) {
+// Register raw markdown variant so static builds expose /raw/*.md for AI agents.
+// Only register when a source page actually exists — otherwise crawler-discovered
+// section index routes try to prerender a /raw/*.md that has no backing file and 404.
+if (import.meta.server && page.value) {
   prerenderRoutes(`/raw${route.path}.md`)
 }
 </script>

--- a/packages/layer/app/utils/navigation.ts
+++ b/packages/layer/app/utils/navigation.ts
@@ -5,3 +5,52 @@ export const flattenNavigation = (items?: ContentNavigationItem[]): ContentNavig
     ? flattenNavigation(item.children)
     : [item],
 ) || []
+
+/**
+ * Strip locale and/or `/docs` levels off the navigation tree so consumers can
+ * render a clean sidebar regardless of source layout.
+ */
+export function transformNavigation(
+  data: ContentNavigationItem[],
+  isI18nEnabled: boolean,
+  locale?: string,
+): ContentNavigationItem[] {
+  if (isI18nEnabled && locale) {
+    const localeResult = data.find(item => item.path === `/${locale}`)?.children || data
+    return localeResult.find(item => item.path === `/${locale}/docs`)?.children || localeResult
+  }
+
+  return data.find(item => item.path === '/docs')?.children || data
+}
+
+export interface BreadcrumbItem {
+  title: string
+  path: string
+}
+
+/**
+ * Walk the navigation tree to build a breadcrumb trail leading to `path`.
+ * Returns undefined when the path is not present in the navigation.
+ */
+export function findPageBreadcrumbs(
+  navigation: ContentNavigationItem[] | undefined,
+  path: string,
+  currentPath: BreadcrumbItem[] = [],
+): BreadcrumbItem[] | undefined {
+  if (!navigation) return undefined
+
+  for (const item of navigation) {
+    const itemPath = [...currentPath, { title: item.title, path: item.path }]
+
+    if (item.path === path) {
+      return itemPath
+    }
+
+    if (item.children) {
+      const found = findPageBreadcrumbs(item.children, path, itemPath)
+      if (found) return found
+    }
+  }
+
+  return undefined
+}

--- a/packages/layer/content.config.ts
+++ b/packages/layer/content.config.ts
@@ -1,9 +1,13 @@
-import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { defineCollection, defineContentConfig, z } from '@nuxt/content'
 import { useNuxt } from '@nuxt/kit'
 import { joinURL } from 'ufo'
-import { z } from 'zod'
+import { docsFolderExists, landingPageExists } from './utils/pages'
+
 const { options } = useNuxt()
 const cwd = joinURL(options.rootDir, 'content')
+
+const hasLandingPage = landingPageExists(options.rootDir)
+const hasDocsFolder = docsFolderExists(options.rootDir)
 
 const docsSchema = z.object({
   links: z.array(z.object({
@@ -14,23 +18,28 @@ const docsSchema = z.object({
   })).optional(),
 })
 
-export default defineContentConfig({
-  collections: {
-    landing: defineCollection({
-      type: 'page',
-      source: {
-        cwd,
-        include: 'index.md',
-      },
-    }),
-    docs: defineCollection({
-      type: 'page',
-      source: {
-        cwd,
-        include: '**',
-        exclude: ['index.md'],
-      },
-      schema: docsSchema,
-    }),
-  },
-})
+const collections: Record<string, ReturnType<typeof defineCollection>> = {
+  docs: defineCollection({
+    type: 'page',
+    source: {
+      cwd,
+      include: hasDocsFolder ? 'docs/**' : '**',
+      prefix: hasDocsFolder ? '/docs' : '/',
+      exclude: ['index.md'],
+    },
+    schema: docsSchema,
+  }),
+}
+
+// Only define the landing collection when the consuming app does not ship its own index.vue
+if (!hasLandingPage) {
+  collections.landing = defineCollection({
+    type: 'page',
+    source: {
+      cwd,
+      include: 'index.md',
+    },
+  })
+}
+
+export default defineContentConfig({ collections })

--- a/packages/layer/content.config.ts
+++ b/packages/layer/content.config.ts
@@ -16,6 +16,8 @@ const docsSchema = z.object({
     to: z.string(),
     target: z.string().optional(),
   })).optional(),
+  // Set to false in frontmatter to exclude a page from /sitemap.xml
+  sitemap: z.boolean().optional(),
 })
 
 const collections: Record<string, ReturnType<typeof defineCollection>> = {

--- a/packages/layer/server/routes/sitemap.xml.ts
+++ b/packages/layer/server/routes/sitemap.xml.ts
@@ -1,0 +1,110 @@
+import type { Collections } from '@nuxt/content'
+import { queryCollection } from '@nuxt/content/server'
+import { joinURL, withTrailingSlash, withoutTrailingSlash } from 'ufo'
+import { inferSiteURL } from '../../utils/meta'
+
+interface SitemapUrl {
+  loc: string
+  lastmod?: string
+}
+
+interface RuntimePublicI18n {
+  locales?: Array<string | { code: string }>
+}
+
+function getAvailableLocales(publicConfig: Record<string, unknown>): string[] {
+  const i18n = publicConfig.i18n as RuntimePublicI18n | undefined
+  if (!i18n?.locales) return []
+  return i18n.locales.map(locale => typeof locale === 'string' ? locale : locale.code)
+}
+
+function isNavigationPath(path: string): boolean {
+  return path.endsWith('.navigation') || path.includes('/.navigation/')
+}
+
+function escapeXml(value: string): string {
+  return value.replace(/[<>&'"]/g, (char) => {
+    switch (char) {
+      case '<': return '&lt;'
+      case '>': return '&gt;'
+      case '&': return '&amp;'
+      case '\'': return '&apos;'
+      case '"': return '&quot;'
+      default: return char
+    }
+  })
+}
+
+function buildSitemap(urls: SitemapUrl[], siteUrl: string): string {
+  const base = siteUrl ? withoutTrailingSlash(siteUrl) : ''
+  const entries = urls
+    .map((url) => {
+      const loc = base ? joinURL(base, url.loc) : url.loc
+      let entry = `  <url>\n    <loc>${escapeXml(loc)}</loc>`
+      if (url.lastmod) {
+        entry += `\n    <lastmod>${escapeXml(url.lastmod)}</lastmod>`
+      }
+      entry += `\n  </url>`
+      return entry
+    })
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries}
+</urlset>`
+}
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event)
+  const siteUrl = inferSiteURL() || ''
+  const baseURL = config.app?.baseURL || '/'
+
+  const availableLocales = getAvailableLocales(config.public as Record<string, unknown>)
+  const collections: string[] = availableLocales.length > 0
+    ? availableLocales.map(locale => `docs_${locale}`)
+    : ['docs']
+
+  if (availableLocales.length > 0) {
+    for (const locale of availableLocales) {
+      collections.push(`landing_${locale}`)
+    }
+  }
+  else {
+    collections.push('landing')
+  }
+
+  const urls: SitemapUrl[] = []
+
+  for (const collection of collections) {
+    try {
+      const pages = await queryCollection(event, collection as keyof Collections)
+        .select('path', 'modifiedAt' as never, 'sitemap' as never)
+        .all() as Array<Record<string, unknown> & { path?: string }>
+
+      for (const page of pages) {
+        const meta = page as Record<string, unknown>
+        const pagePath = page.path || '/'
+
+        if (meta.sitemap === false) continue
+        if (isNavigationPath(pagePath)) continue
+
+        const entry: SitemapUrl = {
+          loc: joinURL(baseURL, pagePath),
+        }
+
+        if (typeof meta.modifiedAt === 'string') {
+          entry.lastmod = meta.modifiedAt.split('T')[0]
+        }
+
+        urls.push(entry)
+      }
+    }
+    catch {
+      // Collection may not exist (e.g. landing is opt-out); skip silently
+    }
+  }
+
+  setResponseHeader(event, 'content-type', 'application/xml')
+  return buildSitemap(urls, siteUrl ? withTrailingSlash(siteUrl) : '')
+})

--- a/packages/layer/server/routes/sitemap.xml.ts
+++ b/packages/layer/server/routes/sitemap.xml.ts
@@ -1,7 +1,7 @@
 import type { Collections } from '@nuxt/content'
 import { queryCollection } from '@nuxt/content/server'
 import { joinURL, withoutTrailingSlash } from 'ufo'
-import { inferSiteURL } from '../../utils/meta'
+import { inferSiteURL } from '../../utils/site-url'
 
 interface SitemapUrl {
   loc: string

--- a/packages/layer/server/routes/sitemap.xml.ts
+++ b/packages/layer/server/routes/sitemap.xml.ts
@@ -1,6 +1,6 @@
 import type { Collections } from '@nuxt/content'
 import { queryCollection } from '@nuxt/content/server'
-import { joinURL, withTrailingSlash, withoutTrailingSlash } from 'ufo'
+import { joinURL, withoutTrailingSlash } from 'ufo'
 import { inferSiteURL } from '../../utils/meta'
 
 interface SitemapUrl {
@@ -36,10 +36,10 @@ function escapeXml(value: string): string {
 }
 
 function buildSitemap(urls: SitemapUrl[], siteUrl: string): string {
-  const base = siteUrl ? withoutTrailingSlash(siteUrl) : ''
+  const base = withoutTrailingSlash(siteUrl)
   const entries = urls
     .map((url) => {
-      const loc = base ? joinURL(base, url.loc) : url.loc
+      const loc = joinURL(base, url.loc)
       let entry = `  <url>\n    <loc>${escapeXml(loc)}</loc>`
       if (url.lastmod) {
         entry += `\n    <lastmod>${escapeXml(url.lastmod)}</lastmod>`
@@ -57,7 +57,15 @@ ${entries}
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
-  const siteUrl = inferSiteURL() || ''
+  const siteUrl = inferSiteURL()
+
+  // Sitemap protocol requires absolute <loc> URLs. Without a site URL we have
+  // no way to produce valid entries — return 404 so consumers don't index a
+  // broken sitemap.
+  if (!siteUrl) {
+    throw createError({ statusCode: 404, statusMessage: 'Sitemap unavailable: site URL is not configured.' })
+  }
+
   const baseURL = config.app?.baseURL || '/'
 
   const availableLocales = getAvailableLocales(config.public as Record<string, unknown>)
@@ -79,7 +87,7 @@ export default defineEventHandler(async (event) => {
   for (const collection of collections) {
     try {
       const pages = await queryCollection(event, collection as keyof Collections)
-        .select('path', 'modifiedAt' as never, 'sitemap' as never)
+        .select('path', 'sitemap' as never)
         .all() as Array<Record<string, unknown> & { path?: string }>
 
       for (const page of pages) {
@@ -89,22 +97,15 @@ export default defineEventHandler(async (event) => {
         if (meta.sitemap === false) continue
         if (isNavigationPath(pagePath)) continue
 
-        const entry: SitemapUrl = {
-          loc: joinURL(baseURL, pagePath),
-        }
-
-        if (typeof meta.modifiedAt === 'string') {
-          entry.lastmod = meta.modifiedAt.split('T')[0]
-        }
-
-        urls.push(entry)
+        urls.push({ loc: joinURL(baseURL, pagePath) })
       }
     }
     catch {
-      // Collection may not exist (e.g. landing is opt-out); skip silently
+      // Collection may not exist (e.g. landing is opt-out, or i18n locale
+      // collections are not registered yet). Skip silently.
     }
   }
 
   setResponseHeader(event, 'content-type', 'application/xml')
-  return buildSitemap(urls, siteUrl ? withTrailingSlash(siteUrl) : '')
+  return buildSitemap(urls, siteUrl)
 })

--- a/packages/layer/utils/meta.ts
+++ b/packages/layer/utils/meta.ts
@@ -1,23 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import process from 'node:process'
-import { withHttps } from 'ufo'
 
-export function inferSiteURL(): string | undefined {
-  const url = (
-    process.env.NUXT_PUBLIC_SITE_URL // Nuxt public runtime config
-    || process.env.NUXT_SITE_URL // Nuxt site config
-    || process.env.VERCEL_PROJECT_PRODUCTION_URL // Vercel production URL
-    || process.env.VERCEL_BRANCH_URL // Vercel branch URL
-    || process.env.VERCEL_URL // Vercel deployment URL
-    || (process.env.NEXT_PUBLIC_VERCEL_URL && `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`)
-    || process.env.URL // Netlify
-    || process.env.CI_PAGES_URL // Gitlab Pages
-    || process.env.CF_PAGES_URL // Cloudflare Pages
-  )
-
-  return url ? withHttps(url) : undefined
-}
+export { inferSiteURL } from './site-url'
 
 export async function getPackageJsonMetadata(dir: string): Promise<{ name: string, description?: string }> {
   try {

--- a/packages/layer/utils/meta.ts
+++ b/packages/layer/utils/meta.ts
@@ -1,15 +1,22 @@
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import process from 'node:process'
+import { withHttps } from 'ufo'
 
 export function inferSiteURL(): string | undefined {
-  return (
-    process.env.NUXT_SITE_URL
+  const url = (
+    process.env.NUXT_PUBLIC_SITE_URL // Nuxt public runtime config
+    || process.env.NUXT_SITE_URL // Nuxt site config
+    || process.env.VERCEL_PROJECT_PRODUCTION_URL // Vercel production URL
+    || process.env.VERCEL_BRANCH_URL // Vercel branch URL
+    || process.env.VERCEL_URL // Vercel deployment URL
     || (process.env.NEXT_PUBLIC_VERCEL_URL && `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`)
     || process.env.URL // Netlify
     || process.env.CI_PAGES_URL // Gitlab Pages
     || process.env.CF_PAGES_URL // Cloudflare Pages
   )
+
+  return url ? withHttps(url) : undefined
 }
 
 export async function getPackageJsonMetadata(dir: string): Promise<{ name: string, description?: string }> {

--- a/packages/layer/utils/pages.ts
+++ b/packages/layer/utils/pages.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'node:fs'
+import { joinURL } from 'ufo'
+
+/**
+ * Returns true when the consuming app ships its own `app/pages/index.vue`,
+ * in which case the layer should not define a `landing` collection.
+ */
+export function landingPageExists(rootDir: string): boolean {
+  return existsSync(joinURL(rootDir, 'app', 'pages', 'index.vue'))
+}
+
+/**
+ * Returns true when a `content/docs/` folder exists (optionally under a locale).
+ * When true, the docs collection should be prefixed with `/docs` and source from that folder.
+ */
+export function docsFolderExists(rootDir: string, locale?: string): boolean {
+  const docsPath = locale
+    ? joinURL(rootDir, 'content', locale, 'docs')
+    : joinURL(rootDir, 'content', 'docs')
+  return existsSync(docsPath)
+}

--- a/packages/layer/utils/pages.ts
+++ b/packages/layer/utils/pages.ts
@@ -1,12 +1,12 @@
 import { existsSync } from 'node:fs'
-import { joinURL } from 'ufo'
+import { join } from 'node:path'
 
 /**
  * Returns true when the consuming app ships its own `app/pages/index.vue`,
  * in which case the layer should not define a `landing` collection.
  */
 export function landingPageExists(rootDir: string): boolean {
-  return existsSync(joinURL(rootDir, 'app', 'pages', 'index.vue'))
+  return existsSync(join(rootDir, 'app', 'pages', 'index.vue'))
 }
 
 /**
@@ -15,7 +15,7 @@ export function landingPageExists(rootDir: string): boolean {
  */
 export function docsFolderExists(rootDir: string, locale?: string): boolean {
   const docsPath = locale
-    ? joinURL(rootDir, 'content', locale, 'docs')
-    : joinURL(rootDir, 'content', 'docs')
+    ? join(rootDir, 'content', locale, 'docs')
+    : join(rootDir, 'content', 'docs')
   return existsSync(docsPath)
 }

--- a/packages/layer/utils/site-url.ts
+++ b/packages/layer/utils/site-url.ts
@@ -1,0 +1,23 @@
+import process from 'node:process'
+import { withHttps } from 'ufo'
+
+/**
+ * Infer the site URL from common deploy-platform env vars. Runtime-safe
+ * (no node:fs / node:path imports) so it can be imported from server routes
+ * bundled into edge runtimes like Cloudflare Workers.
+ */
+export function inferSiteURL(): string | undefined {
+  const url = (
+    process.env.NUXT_PUBLIC_SITE_URL // Nuxt public runtime config
+    || process.env.NUXT_SITE_URL // Nuxt site config
+    || process.env.VERCEL_PROJECT_PRODUCTION_URL // Vercel production URL
+    || process.env.VERCEL_BRANCH_URL // Vercel branch URL
+    || process.env.VERCEL_URL // Vercel deployment URL
+    || (process.env.NEXT_PUBLIC_VERCEL_URL && `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`)
+    || process.env.URL // Netlify
+    || process.env.CI_PAGES_URL // Gitlab Pages
+    || process.env.CF_PAGES_URL // Cloudflare Pages
+  )
+
+  return url ? withHttps(url) : undefined
+}


### PR DESCRIPTION
## Summary

First bundle of ports from `ref/docus` upstream (v5.4.1 → v5.11.0+main). Picks five framework-agnostic changes that don't depend on `@nuxt/ui` or `@nuxtjs/i18n`, so they apply cleanly to our shadcn-vue + Tailwind v4 layer.

Survey: [`docs/docus-upstream-changes.md`](./docs/docus-upstream-changes.md)

## Changes

| # | Area | File | Upstream commit |
| --- | --- | --- | --- |
| 1 | `inferSiteURL` env var coverage + `withHttps` | `packages/layer/utils/meta.ts` | — (gradual upstream improvements) |
| 2 | Register `/raw/*.md` prerender path | `packages/layer/app/pages/[...slug].vue` | `9ceafe6f` |
| 3 | `content.config` auto-detect + `utils/pages.ts` | `packages/layer/content.config.ts`, `packages/layer/utils/pages.ts` | `f9e999d8`, `99c78508` |
| 4 | `transformNavigation` + `findPageBreadcrumbs` | `packages/layer/app/utils/navigation.ts` | (used across docus) |
| 5 | `sitemap.xml` route | `packages/layer/server/routes/sitemap.xml.ts` | `45bffbc5`, `cd2c62e4` |

## Behavioural notes

- **`landing` collection becomes opt-out**: if the consuming app ships `app/pages/index.vue`, the layer skips defining a `landing` collection. Existing apps with only a `content/index.md` are unaffected.
- **`/docs` auto-prefix**: if `content/docs/` exists, the docs collection sources from there and uses `/docs` as the prefix. Flat `content/` layouts continue to work as before.
- **Sitemap route is opt-in by URL**: hit `/sitemap.xml` to render; nothing else references it yet.

## Verification

- `bun lint` — clean (only an unrelated baseline-browser-mapping data warning)
- `cd packages/layer && bun typecheck` — no new errors (pre-existing errors in `AppHeaderLogo`, `AppSearch`, `ComponentsList`, `DialogScrollContent`, `modules/config.ts`, `nuxt.config.ts`, `pages/[...slug].vue` TOC code remain; none touched here)

## Not included (deferred to follow-ups)

Per the survey, these need additional dependencies or stack work:
- MCP server + Skills + Vercel markdown-rewrite (AI/agent bundle)
- `useSeo` JSON-LD composable (hreflang requires `@nuxtjs/i18n`)
- `d` shortcut for color mode (needs vueuse-based reimplementation)
