### PR TITLE
feat(seo): add useSeo composable with JSON-LD and canonical

### DIFF
--- a/packages/layer/app/composables/useSeo.ts
+++ b/packages/layer/app/composables/useSeo.ts
@@ -1,0 +1,195 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { BreadcrumbItem } from '../utils/navigation'
+import { joinURL, withoutTrailingSlash } from 'ufo'
+import { inferSiteURL } from '../../utils/site-url'
+
+export interface UseSeoOptions {
+  /**
+   * Page title.
+   */
+  title: MaybeRefOrGetter<string | undefined>
+  /**
+   * Page description.
+   */
+  description: MaybeRefOrGetter<string | undefined>
+  /**
+   * Page type for `og:type` (default: `'article'`).
+   */
+  type?: MaybeRefOrGetter<'website' | 'article'>
+  /**
+   * Custom OG image URL (absolute).
+   */
+  ogImage?: MaybeRefOrGetter<string | undefined>
+  /**
+   * Published date (ISO string) for Article schema.
+   */
+  publishedAt?: MaybeRefOrGetter<string | undefined>
+  /**
+   * Modified date (ISO string) for Article schema.
+   */
+  modifiedAt?: MaybeRefOrGetter<string | undefined>
+  /**
+   * Breadcrumb trail for BreadcrumbList schema.
+   */
+  breadcrumbs?: MaybeRefOrGetter<BreadcrumbItem[] | undefined>
+}
+
+type JsonLdScript = {
+  type: 'application/ld+json'
+  innerHTML: string
+} & { [key: `data-${string}`]: string }
+
+type LinkTag = {
+  rel: string
+  href?: string
+  hreflang?: string
+} & { [key: `data-${string}`]: string }
+
+/**
+ * Comprehensive SEO setup for documentation pages:
+ *
+ * - Title/description meta + OpenGraph + Twitter card tags
+ * - Canonical `<link>` resolved from app config / inferred site URL
+ * - JSON-LD structured data (Article or WebSite, optional BreadcrumbList)
+ *
+ * Ported from upstream docus commit `d283f9aa`
+ * (`feat(layer): add more seo optimization`). Hreflang emission is deferred
+ * until `@nuxtjs/i18n` is wired into the layer.
+ */
+export function useSeo(options: UseSeoOptions): void {
+  const route = useRoute()
+  const appConfig = useAppConfig()
+
+  const title = computed(() => toValue(options.title))
+  const description = computed(() => toValue(options.description))
+  const type = computed<'website' | 'article'>(() => toValue(options.type) ?? 'article')
+  const ogImage = computed(() => toValue(options.ogImage))
+  const publishedAt = computed(() => toValue(options.publishedAt))
+  const modifiedAt = computed(() => toValue(options.modifiedAt))
+  const breadcrumbs = computed(() => toValue(options.breadcrumbs))
+
+  // Resolve a usable site URL: prefer the explicit app config (populated by
+  // `modules/config.ts` at build time), fall back to env inference for
+  // server-side rendering.
+  const baseUrl = computed<string | undefined>(() => {
+    const configured = appConfig.docs?.url
+    const resolved = (typeof configured === 'string' && configured.length > 0)
+      ? configured
+      : inferSiteURL()
+    return resolved ? withoutTrailingSlash(resolved) : undefined
+  })
+
+  const canonicalUrl = computed<string | undefined>(() => {
+    if (!baseUrl.value) return undefined
+    return joinURL(baseUrl.value, route.path)
+  })
+
+  const siteName = computed<string | undefined>(() => {
+    const name = appConfig.docs?.title
+    return typeof name === 'string' && name.length > 0 ? name : undefined
+  })
+
+  // Standard meta tags (title/description/OG/Twitter).
+  useSeoMeta({
+    title,
+    description,
+    ogTitle: title,
+    ogDescription: description,
+    ogType: type,
+    ogUrl: canonicalUrl,
+    ogImage,
+    twitterCard: 'summary_large_image',
+    twitterTitle: title,
+    twitterDescription: description,
+    twitterImage: ogImage,
+  })
+
+  // Canonical + (future) hreflang links.
+  useHead({
+    link: computed<LinkTag[]>(() => {
+      const links: LinkTag[] = []
+
+      if (canonicalUrl.value) {
+        links.push({ rel: 'canonical', href: canonicalUrl.value })
+      }
+
+      // TODO: emit hreflang tags once @nuxtjs/i18n is wired in
+      // (upstream uses runtimeConfig.public.i18n).
+
+      return links
+    }),
+  })
+
+  // JSON-LD structured data.
+  useHead({
+    script: computed<JsonLdScript[]>(() => {
+      const scripts: JsonLdScript[] = []
+
+      if (!baseUrl.value || !title.value) return scripts
+
+      const pageUrl = joinURL(baseUrl.value, route.path)
+
+      if (type.value === 'article') {
+        const articleSchema: Record<string, unknown> = {
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          'headline': title.value,
+          'description': description.value,
+          'url': pageUrl,
+          'mainEntityOfPage': {
+            '@type': 'WebPage',
+            '@id': pageUrl,
+          },
+        }
+        if (publishedAt.value) {
+          articleSchema.datePublished = publishedAt.value
+        }
+        if (modifiedAt.value) {
+          articleSchema.dateModified = modifiedAt.value
+        }
+        if (siteName.value) {
+          articleSchema.publisher = {
+            '@type': 'Organization',
+            'name': siteName.value,
+          }
+        }
+        scripts.push({
+          type: 'application/ld+json',
+          innerHTML: JSON.stringify(articleSchema),
+        })
+      }
+      else if (type.value === 'website') {
+        const websiteSchema: Record<string, unknown> = {
+          '@context': 'https://schema.org',
+          '@type': 'WebSite',
+          'name': siteName.value ?? title.value,
+          'description': description.value,
+          'url': baseUrl.value,
+        }
+        scripts.push({
+          type: 'application/ld+json',
+          innerHTML: JSON.stringify(websiteSchema),
+        })
+      }
+
+      if (breadcrumbs.value && breadcrumbs.value.length > 0) {
+        const breadcrumbSchema = {
+          '@context': 'https://schema.org',
+          '@type': 'BreadcrumbList',
+          'itemListElement': breadcrumbs.value.map((item, index) => ({
+            '@type': 'ListItem',
+            'position': index + 1,
+            'name': item.title,
+            'item': joinURL(baseUrl.value!, item.path),
+          })),
+        }
+        scripts.push({
+          type: 'application/ld+json',
+          innerHTML: JSON.stringify(breadcrumbSchema),
+        })
+      }
+
+      return scripts
+    }),
+  })
+}

--- a/packages/layer/app/composables/useSeo.ts
+++ b/packages/layer/app/composables/useSeo.ts
@@ -36,7 +36,7 @@ export interface UseSeoOptions {
 
 type JsonLdScript = {
   type: 'application/ld+json'
-  innerHTML: string
+  textContent: string
 } & { [key: `data-${string}`]: string }
 
 type LinkTag = {
@@ -125,51 +125,54 @@ export function useSeo(options: UseSeoOptions): void {
     script: computed<JsonLdScript[]>(() => {
       const scripts: JsonLdScript[] = []
 
-      if (!baseUrl.value || !title.value) return scripts
+      if (!baseUrl.value) return scripts
 
       const pageUrl = joinURL(baseUrl.value, route.path)
 
-      if (type.value === 'article') {
-        const articleSchema: Record<string, unknown> = {
-          '@context': 'https://schema.org',
-          '@type': 'Article',
-          'headline': title.value,
-          'description': description.value,
-          'url': pageUrl,
-          'mainEntityOfPage': {
-            '@type': 'WebPage',
-            '@id': pageUrl,
-          },
-        }
-        if (publishedAt.value) {
-          articleSchema.datePublished = publishedAt.value
-        }
-        if (modifiedAt.value) {
-          articleSchema.dateModified = modifiedAt.value
-        }
-        if (siteName.value) {
-          articleSchema.publisher = {
-            '@type': 'Organization',
-            'name': siteName.value,
+      // Article/WebSite schemas require a title; breadcrumbs do not.
+      if (title.value) {
+        if (type.value === 'article') {
+          const articleSchema: Record<string, unknown> = {
+            '@context': 'https://schema.org',
+            '@type': 'Article',
+            'headline': title.value,
+            'description': description.value,
+            'url': pageUrl,
+            'mainEntityOfPage': {
+              '@type': 'WebPage',
+              '@id': pageUrl,
+            },
           }
+          if (publishedAt.value) {
+            articleSchema.datePublished = publishedAt.value
+          }
+          if (modifiedAt.value) {
+            articleSchema.dateModified = modifiedAt.value
+          }
+          if (siteName.value) {
+            articleSchema.publisher = {
+              '@type': 'Organization',
+              'name': siteName.value,
+            }
+          }
+          scripts.push({
+            type: 'application/ld+json',
+            textContent: JSON.stringify(articleSchema),
+          })
         }
-        scripts.push({
-          type: 'application/ld+json',
-          innerHTML: JSON.stringify(articleSchema),
-        })
-      }
-      else if (type.value === 'website') {
-        const websiteSchema: Record<string, unknown> = {
-          '@context': 'https://schema.org',
-          '@type': 'WebSite',
-          'name': siteName.value ?? title.value,
-          'description': description.value,
-          'url': baseUrl.value,
+        else if (type.value === 'website') {
+          const websiteSchema: Record<string, unknown> = {
+            '@context': 'https://schema.org',
+            '@type': 'WebSite',
+            'name': siteName.value ?? title.value,
+            'description': description.value,
+            'url': baseUrl.value,
+          }
+          scripts.push({
+            type: 'application/ld+json',
+            textContent: JSON.stringify(websiteSchema),
+          })
         }
-        scripts.push({
-          type: 'application/ld+json',
-          innerHTML: JSON.stringify(websiteSchema),
-        })
       }
 
       if (breadcrumbs.value && breadcrumbs.value.length > 0) {
@@ -185,7 +188,7 @@ export function useSeo(options: UseSeoOptions): void {
         }
         scripts.push({
           type: 'application/ld+json',
-          innerHTML: JSON.stringify(breadcrumbSchema),
+          textContent: JSON.stringify(breadcrumbSchema),
         })
       }
 

--- a/packages/layer/app/pages/[...slug].vue
+++ b/packages/layer/app/pages/[...slug].vue
@@ -11,6 +11,10 @@ const { data: page } = await useAsyncData(`docs-${route.path}`, () =>
 const { data: surround } = await useAsyncData(`surround-${route.path}`, () =>
   queryCollectionItemSurroundings('docs', route.path))
 
+const { data: navigation } = await useNavigation()
+
+const breadcrumbs = computed(() => findPageBreadcrumbs(navigation.value, route.path))
+
 // Extract TOC from page body
 const _toc = computed(() => {
   if (!page.value?.body)
@@ -59,9 +63,13 @@ const _toc = computed(() => {
   return headings
 })
 
-useSeoMeta({
-  title: page.value?.title,
-  description: page.value?.description,
+useSeo({
+  title: () => page.value?.title,
+  description: () => page.value?.description,
+  type: 'article',
+  publishedAt: () => (page.value as { publishedAt?: string } | null | undefined)?.publishedAt,
+  modifiedAt: () => (page.value as { modifiedAt?: string } | null | undefined)?.modifiedAt,
+  breadcrumbs,
 })
 
 // Register raw markdown variant so static builds expose /raw/*.md for AI agents.


### PR DESCRIPTION
## Summary

Ports upstream docus commit [`d283f9aa`](https://github.com/nuxt-content/docus/commit/d283f9aa) (`feat(layer): add more seo optimization`) — item **#10** from [`docs/docus-upstream-changes.md`](../blob/main/docs/docus-upstream-changes.md#10-useseo-composable).

Follows on from #27 (first docus upstream bundle).

## What's in the box

- New `packages/layer/app/composables/useSeo.ts` (auto-imported)
  - Reactive `title` / `description` flowing into `useSeoMeta` with full OpenGraph + Twitter card meta
  - Canonical `<link>` resolved from `useAppConfig().docs.url` (populated by `modules/config.ts`) with an `inferSiteURL()` fallback so SSR works in CI environments where `app.config` isn't pre-populated
  - JSON-LD `Article` or `WebSite` schema (chosen by `type`) plus an optional `BreadcrumbList` script when the caller supplies a trail
- `packages/layer/app/pages/[...slug].vue` now calls `useSeo` with breadcrumbs computed from `useNavigation` + `findPageBreadcrumbs` (both already landed in #27)

## Hreflang deferral

Upstream's `useSeo` also emits `<link rel="alternate" hreflang="...">` tags driven by `useDocusI18n` / `runtimeConfig.public.i18n`. Our layer doesn't ship `@nuxtjs/i18n` yet, so the hreflang branch is left as a `TODO` comment inside `useSeo.ts` — to be wired up alongside the i18n module work tracked separately in the survey.

## Verification

```
bun lint        # passes
bun typecheck   # passes for new code (pre-existing errors unchanged)
bun dev         # http://localhost:3001/docs/getting-started/introduction shows:
                #   <link rel="canonical" ...>
                #   <meta property="og:*" ...>
                #   <meta name="twitter:*" ...>
                #   <script type="application/ld+json"> Article + BreadcrumbList
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `useSeo` composable to set canonical links, OpenGraph/Twitter meta, and JSON-LD (Article/WebSite + Breadcrumbs) for better SEO. Docs pages now use `useSeo` with computed breadcrumbs.

- **New Features**
  - Canonical URL resolved from `useAppConfig().docs.url` with `inferSiteURL()` fallback.
  - JSON-LD scripts: `Article` or `WebSite`, plus `BreadcrumbList` when breadcrumbs are provided.
  - OpenGraph and Twitter meta from reactive `title`/`description`, with optional `ogImage`, `publishedAt`, and `modifiedAt`.
  - `[...slug].vue` computes breadcrumbs via `useNavigation` + `findPageBreadcrumbs` and calls `useSeo`.
  - Hreflang tags deferred until `@nuxtjs/i18n` is added.

- **Bug Fixes**
  - Use `textContent` (not `innerHTML`) for JSON-LD scripts to avoid XSS.
  - Allow `BreadcrumbList` to render even when `title` is unset.

<sup>Written for commit a50c22eb312eb193da9d07eb17562a6c88fe9ef7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

