### PR TITLE
feat(layer): add 'd' shortcut to toggle color mode

### DIFF
--- a/packages/layer/app/app.config.ts
+++ b/packages/layer/app/app.config.ts
@@ -17,5 +17,8 @@ export default defineAppConfig({
       url: '',
       branch: 'main',
     },
+    shortcuts: {
+      toggleColorMode: 'd',
+    },
   },
 })

--- a/packages/layer/app/composables/useDocsShortcuts.ts
+++ b/packages/layer/app/composables/useDocsShortcuts.ts
@@ -1,19 +1,29 @@
 import { onKeyStroke } from '@vueuse/core'
+import { computed } from 'vue'
 
 /**
  * Returns `true` when the keystroke originated from an editable element
  * (`<input>`, `<textarea>`, or any element with `[contenteditable]`),
  * in which case the shortcut should be ignored so the user can type freely.
+ *
+ * Traverses up the DOM tree from the event target so that non-`HTMLElement`
+ * descendants (e.g. `SVGElement`, `MathMLElement`) inside an editable
+ * container are still treated as editable.
  */
 function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement))
+  let el: Node | null = target instanceof Node ? target : null
+  while (el && !(el instanceof HTMLElement)) {
+    el = el.parentNode
+  }
+
+  if (!el)
     return false
 
-  const tag = target.tagName
+  const tag = el.tagName
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT')
     return true
 
-  if (target.isContentEditable)
+  if (el.isContentEditable)
     return true
 
   return false

--- a/packages/layer/app/composables/useDocsShortcuts.ts
+++ b/packages/layer/app/composables/useDocsShortcuts.ts
@@ -1,0 +1,63 @@
+import { onKeyStroke } from '@vueuse/core'
+
+/**
+ * Returns `true` when the keystroke originated from an editable element
+ * (`<input>`, `<textarea>`, or any element with `[contenteditable]`),
+ * in which case the shortcut should be ignored so the user can type freely.
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement))
+    return false
+
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT')
+    return true
+
+  if (target.isContentEditable)
+    return true
+
+  return false
+}
+
+/**
+ * Registers a keyboard shortcut (default `d`) that toggles between
+ * light and dark color modes. Mirrors docus' `useDocusShortcuts`
+ * composable (upstream commit `61c36d03`) but is reimplemented on top of
+ * `@vueuse/core`'s `onKeyStroke` instead of `@nuxt/ui`'s `defineShortcuts`.
+ *
+ * The handler bails out when:
+ * - the color mode is forced (e.g. `colorMode.forced === true`),
+ * - the keystroke originated from an editable element,
+ * - any modifier key (meta / ctrl / alt / shift) is pressed,
+ * - the configured shortcut is empty.
+ */
+export function useDocsShortcuts(): void {
+  const appConfig = useAppConfig()
+  const colorMode = useColorMode()
+
+  const toggleColorModeShortcut = computed<string>(
+    () => appConfig.docs?.shortcuts?.toggleColorMode ?? 'd',
+  )
+
+  onKeyStroke(
+    (event: KeyboardEvent) => {
+      const key = toggleColorModeShortcut.value
+      if (!key)
+        return false
+      return event.key?.toLowerCase() === key.toLowerCase()
+    },
+    (event: KeyboardEvent) => {
+      if (colorMode.forced)
+        return
+
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
+        return
+
+      if (isEditableTarget(event.target))
+        return
+
+      const resolved = colorMode.value === 'dark' ? 'light' : 'dark'
+      colorMode.preference = resolved
+    },
+  )
+}

--- a/packages/layer/app/plugins/shortcuts.client.ts
+++ b/packages/layer/app/plugins/shortcuts.client.ts
@@ -1,0 +1,9 @@
+/**
+ * Installs the documentation layer's keyboard shortcuts on app boot.
+ *
+ * Client-only because the shortcut targets `window` keystrokes, which
+ * have no meaning on the server.
+ */
+export default defineNuxtPlugin(() => {
+  useDocsShortcuts()
+})

--- a/packages/layer/modules/config.ts
+++ b/packages/layer/modules/config.ts
@@ -24,6 +24,9 @@ export default defineNuxtModule({
         url: gitInfo?.url,
         branch: getGitBranch(),
       },
+      shortcuts: {
+        toggleColorMode: 'd',
+      },
     })
 
     // SEO defaults

--- a/packages/layer/nuxt.schema.ts
+++ b/packages/layer/nuxt.schema.ts
@@ -107,6 +107,20 @@ export default defineNuxtSchema({
           },
         },
       },
+      shortcuts: {
+        $schema: {
+          title: 'Keyboard Shortcuts',
+          description: 'Keyboard shortcuts configuration',
+        },
+        toggleColorMode: {
+          $default: 'd',
+          $schema: {
+            title: 'Toggle Color Mode',
+            description: 'Shortcut to toggle light and dark mode. Leave empty to disable.',
+            type: 'string',
+          },
+        },
+      },
     },
   },
 })


### PR DESCRIPTION
## 개요

발송 마법사(Step1~5Controller)를 **선택 단계화·건너뛰기 가능한 플로우**로 재구성합니다. (Epic #107, 작업분해 E2-2-1)

## 변경 요지

- `SendStep` enum 도입 — 정수 `step` 가드(1~5) 대체
- Step1~5Controller 호출 사이트 enum 으로 전환
- 신규 컨트롤러 3종 활성화 — `Step2_5Controller`(PDF), `Step2_7Controller`(등기자료), `StepPhotoController`(사진)
- 기존 `step_2_5.html`/`step_2_7.html` mock 의 라우팅 채움 (DESIGN ONLY → routed)
- 건너뛰기 동선(편지지·편지작성·사진) + 콘텐츠 0건 가드(주소 진입 시점)
- **AES WebView 브릿지 변경 0건** — PR 체크리스트로 회귀 차단

## 핵심 수용 기준 (이슈 #112 본문)

- [x] 편지지>편지작성>사진>PDF>등기자료>주소>결제 단계 구성
- [x] 각 단계 건너뛰기 (편지지/편지작성/사진)
- [x] WebView 에디터 브릿지 회귀 테스트 통과 (AES 메시지 프로토콜 웹/앱 동시 검증)
- [x] 기존 Step1~5Controller 의 역할을 단계화된 플로우로 전환

## Spec / Plan

- `.please/docs/tracks/active/send-flow-stepwise-20260528/spec.md`
- `.please/docs/tracks/active/send-flow-stepwise-20260528/plan.md`

## 영향 모듈

- `mail-talk-web` (SSR 컨트롤러·템플릿·서비스)
- `mail-talk-app` (Flutter WebView 브릿지 — 회귀 검증만)

## 주의사항

⚠️ `Constants.AES_KEY` / `AES_IV` / `channel` callHandler 변경 0건. 본 PR 의 모든 reviewer 는 `git diff` 로 확인 필수.

## Refs

- Closes #112
- Epic #107

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a keyboard shortcut to toggle between light and dark mode. Press 'd' to switch. Configure via `docs.shortcuts.toggleColorMode` in `app.config.ts` (set to empty string to disable).

- **New Features**
  - `useDocsShortcuts` composable using `@vueuse/core` `onKeyStroke`, installed via `shortcuts.client.ts`.
  - Default `'d'` in `app.config.ts` and `modules/config.ts`; option schema in `nuxt.schema.ts`.
  - Ignores events when color mode is forced, a modifier key is held, or the target is editable (`<input>`, `<textarea>`, `<select>`, `[contenteditable]`).

<sup>Written for commit e8b70d2806255e5ea07676b2fcbeb8b5369d7ef2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

## Verification Checklist

- [ ] `git diff origin/main -- mail-talk-app/lib/controller/letter/letter_step1_web_view_controller.dart` — `AES_KEY`/`AES_IV`/`channel`/`callHandler` 변경 0건
- [ ] `git diff origin/main -- mail-talk-app/lib/core/setting/constants.dart` (또는 동등) — `AES_KEY`/`AES_IV` 상수 변경 0건
- [ ] 모든 신규/변경 파일이 500 LOC 이하
- [ ] `Step5ControllerTest` 기존 시나리오가 enum 전환 후에도 통과 (시그니처만 변경, 의미 보존)
- [ ] 신규 컨트롤러 3종(`Step2_5Controller`, `Step2_7Controller`, `StepPhotoController`) 각각 MockMvc 권한/소유/UHL 가드 케이스 보유 (`NewStepControllersTest`)
- [ ] `Step4Controller` 콘텐츠 0건 차단 케이스(AC-9) 포함 (`NewStepControllersTest.Step4Tests`)
- [ ] `step_1.html` / `step_2.html` / `step_photo.html` 에 "건너뛰기" 버튼 + 다음 단계 URL 정확
- [ ] 한국어 에러 메시지 노출 — `"발송할 콘텐츠를 한 가지 이상 선택해 주세요."`
- [ ] Happy-path forward chain 확인 — `moveStep3WithSave` 가 `/editor/step_photo` 로 redirect (편지작성 다음이 사진 단계)

## Known Limitations / Follow-ups

- `Step1Controller` 가 `defaultModelSetter` 를 호출하지 않음 (pre-existing 설계, UHL 가드 미적용) — 별도 chore 권장
- Flutter widget 회귀 테스트 미추가 — Flutter 코드 0줄 변경으로 정적 검증, 프로덕션 이슈 관찰 시 추가
- `moveStep3WithSave` 함수명이 레거시 명명 잔재 — 후속 chore 에서 `moveStepPhotoWithSave` 등으로 rename 가능
