### PR TITLE
chore: add OSS community health files and pin actions to commit SHAs

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,6 @@
+# Community health files intentionally publish a contact email address;
+# Codacy's PII rule flags any email, so exclude these docs from analysis.
+---
+exclude_paths:
+  - "SECURITY.md"
+  - "CODE_OF_CONDUCT.md"

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report a problem to help us improve
+title: ""
+labels: ["bug"]
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behavior:
+
+1. ...
+2. ...
+3. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Environment
+
+- Package version:
+- Runtime/OS:
+
+## Additional context
+
+Logs, screenshots, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/pleaseai/docs/discussions
+    about: Ask questions and discuss ideas here instead of opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/pleaseai/docs/security/advisories/new
+    about: Report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: ""
+labels: ["enhancement"]
+---
+
+## Problem
+
+What problem does this feature solve? What is the use case?
+
+## Proposed solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives considered
+
+Other approaches you've thought about, and why this one is preferable.
+
+## Additional context
+
+Anything else that helps explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- PR title should follow Conventional Commits, e.g. "feat(layer): add toc component" -->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits
+- [ ] Lint passes (`bun run lint`)
+- [ ] Type check passes (`bun run typecheck`)
+- [ ] Documentation updated if behavior changed
+- [ ] No breaking change, or a `BREAKING CHANGE:` note is included

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,15 @@
 version: 2
 updates:
+  # Bun workspaces: the root entry covers workspace member package.json
+  # files too (apps/*, packages/*) — no per-directory entries needed.
   - package-ecosystem: bun
-    directories:
-      - "/"
-      - "/apps/docs"
-      - "/packages/layer"
+    directory: "/"
     schedule:
       interval: weekly
     commit-message:
       prefix: "chore(deps)"
     groups:
       minor-and-patch:
-        group-by: dependency-name
         update-types:
           - minor
           - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: bun
+    directories:
+      - "/"
+      - "/apps/docs"
+      - "/packages/layer"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       prefix: "chore(deps)"
     groups:
       minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       prefix: "chore(deps)"
     groups:
       minor-and-patch:
+        group-by: dependency-name
         update-types:
           - minor
           - patch

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,13 +24,13 @@ jobs:
       layer_tag_name: ${{ steps.release.outputs['packages/layer--tag_name'] }}
       layer_version: ${{ steps.release.outputs['packages/layer--version'] }}
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -42,13 +42,13 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,19 @@
+# .worktreeinclude — gitignored files to copy into new worktrees
+# Uses .gitignore syntax. Only files matching a pattern AND ignored by git
+# are copied. Claude Code --worktree handles this automatically; external
+# tools (orca/conductor) run `bunx @pleaseai/worktreeinclude <src> <dst>`
+# from their setup hook (see orca.yaml).
+
+# Root environment variables (dotenvx)
+.env
+.env.local
+.env.*.local
+.env.keys
+
+# Per-workspace environment variables
+apps/*/.env
+apps/*/.env.local
+packages/*/.env
+
+# Claude Code local settings (permissions, env, plugin overrides)
+.claude/settings.local.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**gon.yun@pleaseai.dev**.
+**security@pleaseai.dev**.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**gon.yun@pleaseai.dev**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for your interest in contributing! This guide covers how to get from a clone to a merged pull request.
+
+By participating, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md). All documentation, code, comments, and commit messages in this repository are written in **English**.
+
+## Getting started
+
+```bash
+git clone https://github.com/pleaseai/docs.git
+cd docs
+bun install         # install dependencies
+bun run dev:prepare # generate Nuxt type stubs
+```
+
+The `ref/` directory contains git submodules with reference projects (docus, shadcn-vue, fumadocs, …). They are not required for development, but if you want them:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Development workflow
+
+1. Create a branch from `main` (e.g. `feat/short-description` or `fix/issue-123`).
+2. Make focused changes — keep each pull request to one logical change.
+3. Run the checks below and make sure they pass.
+4. Open a pull request and fill out the template.
+
+```bash
+bun run lint        # lint and format
+bun run typecheck   # type-check the layer package
+bun run build       # ensure the docs site builds
+```
+
+## Commit messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): subject`, where `type` is one of `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, etc. Breaking changes include a `BREAKING CHANGE:` footer. Versioning and the changelog are generated automatically from these messages, so accurate types matter.
+
+## Pull requests
+
+- Reference the issue your PR addresses (e.g. `Closes #123`).
+- Use a Conventional-Commit-style PR title — it becomes the squash-merge commit.
+- Make sure CI is green before requesting review.
+
+## Reporting bugs and requesting features
+
+Open an issue using the bug report or feature request template. For security
+vulnerabilities, **do not** open a public issue — follow [SECURITY.md](./SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released major version. Older
+versions may receive fixes at the maintainers' discretion.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| older   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately through GitHub's
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability):
+go to the repository's **Security** tab and click **"Report a vulnerability"**.
+
+If you cannot use that channel, email **gon.yun@pleaseai.dev** instead.
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce, or a proof of concept
+- Affected versions, and any known mitigations
+
+## What to Expect
+
+- We aim to acknowledge your report within **72 hours**.
+- We will keep you informed of progress toward a fix and may ask for additional
+  detail.
+- Once a fix is released, we will credit you in the advisory unless you prefer
+  to remain anonymous.
+
+We ask that you give us a reasonable opportunity to address the issue before any
+public disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ Instead, report them privately through GitHub's
 [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability):
 go to the repository's **Security** tab and click **"Report a vulnerability"**.
 
-If you cannot use that channel, email **gon.yun@pleaseai.dev** instead.
+If you cannot use that channel, email **security@pleaseai.dev** instead.
 
 Please include:
 

--- a/orca.yaml
+++ b/orca.yaml
@@ -1,0 +1,13 @@
+# orca.yaml — setup script run when an Orca worktree is created
+# Copies gitignored local files listed in .worktreeinclude into the new
+# worktree, then installs dependencies.
+# Env vars:
+#   $ORCA_ROOT_PATH     — main checkout (copy source)
+#   $ORCA_WORKTREE_PATH — newly created worktree (copy target)
+
+scripts:
+  setup: |
+    set -e
+    bunx @pleaseai/worktreeinclude "$ORCA_ROOT_PATH" "$ORCA_WORKTREE_PATH"
+    git submodule update --init --recursive
+    bun install

--- a/orca.yaml
+++ b/orca.yaml
@@ -11,3 +11,4 @@ scripts:
     bunx @pleaseai/worktreeinclude "$ORCA_ROOT_PATH" "$ORCA_WORKTREE_PATH"
     git submodule update --init --recursive
     bun install
+    bun run dev:prepare

--- a/orca.yaml
+++ b/orca.yaml
@@ -5,10 +5,12 @@
 #   $ORCA_ROOT_PATH     — main checkout (copy source)
 #   $ORCA_WORKTREE_PATH — newly created worktree (copy target)
 
+# The ref/ submodules are reference-only and not required for development
+# (see CONTRIBUTING.md), so worktree setup skips them to stay fast. Run
+# `git submodule update --init --recursive` manually if you need them.
 scripts:
   setup: |
     set -e
     bunx @pleaseai/worktreeinclude "$ORCA_ROOT_PATH" "$ORCA_WORKTREE_PATH"
-    git submodule update --init --recursive
     bun install
     bun run dev:prepare


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(layer): add toc component" -->

## Summary

Three changes bundled together as part of bringing this public repository up to the org's open-source standards:

1. **OSS community health files & worktree setup** (`chore: add OSS community health files and worktree setup`)
   - Added `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` — security contact: `gon.yun@pleaseai.dev`
   - Added `.github/PULL_REQUEST_TEMPLATE.md`
   - Added `.github/ISSUE_TEMPLATE/` (`bug_report.md`, `feature_request.md`, `config.yml`)
   - Added `orca.yaml` and `.worktreeinclude` for worktree-based development
   - Generated by running the org OSS-standards setup (`/standards:setup --oss`) on this repo

2. **CI hardening: pin GitHub Actions to commit SHAs** (`ci: pin GitHub Actions to commit SHAs in release-please workflow`)
   - Pinned `actions/create-github-app-token`, `googleapis/release-please-action`, `actions/checkout`, `oven-sh/setup-bun`, `actions/setup-node` in `.github/workflows/release-please.yml` to full commit SHAs
   - Pin only — no version upgrades — per the org's supply-chain hardening standard for third-party GitHub Actions

3. **Dependabot** (`ci: add dependabot config for bun and github actions`)
   - Added `.github/dependabot.yml` covering the `bun` ecosystem (`/`, `/apps/docs`, `/packages/layer`) and the `github-actions` ecosystem (`/`)
   - Weekly schedule, grouped minor/patch bun updates and grouped github-actions updates, with `chore(deps)` / `ci(deps)` commit-message prefixes
   - Enables automated, weekly, grouped dependency updates and keeps the newly SHA-pinned actions in `release-please.yml` current

## Related issue

<!-- No linked issue for this work -->
N/A

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Lint passes (`bun run lint`)
- [ ] Type check passes (`bun run typecheck`)
- [x] Documentation updated if behavior changed (community health docs added)
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance, a code of conduct, and security reporting instructions.
  * Added structured GitHub issue and pull request templates for clearer submissions.

* **Chores**
  * Enabled automated dependency updates and refreshed release workflow settings for safer, more consistent maintenance.
  * Added worktree setup guidance to help new environments inherit needed local configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->