### PR TITLE
ci: add zizmor workflow security analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,21 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write # SARIF upload to code scanning
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7


### PR DESCRIPTION
## Summary

Adds [zizmor](https://github.com/zizmorcore/zizmor) static analysis for GitHub Actions workflows, per the org OSS standards (`standards:open-source-standards` / `github-actions:github-actions-security`).

- Runs on push to `main` and on every PR
- Detects unpinned actions, excessive permissions, template injection, dangerous triggers, and cache poisoning
- Uploads findings as SARIF to the Security tab (code scanning) — free on public repos
- Both actions pinned to full commit SHAs

## Related repo settings (already applied)

- Secret scanning + push protection: enabled
- CodeQL default setup: enabled (JS/TS)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `zizmor` static analysis for GitHub Actions workflows to catch insecure patterns and surface results in Code Scanning. Runs on pushes to `main` and all PRs, uploading SARIF to the Security tab.

- **New Features**
  - Detects unpinned actions, excessive permissions, template injection, risky triggers, and cache poisoning.
  - Uses least-privilege permissions; only `security-events: write` for SARIF upload.
  - Pins `actions/checkout` and `zizmorcore/zizmor-action` to commit SHAs.

<sup>Written for commit 7a0f686f6e770d3431cf8b7a0ccb29eec2c46c5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

