### PR TITLE
chore: update bun to 1.3.14

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-please-workspace",
   "version": "1.0.0",
-  "packageManager": "bun@1.3.5",
+  "packageManager": "bun@1.3.14",
   "description": "",
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(layer): add toc component" -->

## Summary

Bump the project's bun version from 1.3.5 to 1.3.14, keeping the `packageManager` field in package.json and the CI `setup-bun` action version in sync.

### Changes

- `package.json`: `packageManager` `bun@1.3.5` → `bun@1.3.14`
- `.github/workflows/release-please.yml`: `setup-bun` `bun-version` `latest` → `1.3.14` (pin CI to match packageManager for reproducible installs)

### Test Plan

- [x] `bun install --frozen-lockfile` succeeds with bun 1.3.14; lockfile unchanged
- [x] `bun run lint` passes
- [ ] `cd packages/layer && bun typecheck` — fails with pre-existing, unrelated errors (present identically on `main`/`ed8b96e`); not introduced by this change

## Related issue

N/A — not tied to a GitHub issue.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Lint passes (`bun run lint`)
- [ ] Type check passes (`bun run typecheck`) — pre-existing failures unrelated to this change (verified identical on `main`)
- [ ] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `bun` to 1.3.14 and pin CI to the same version for reproducible installs and builds.

- **Dependencies**
  - `package.json`: set `packageManager` to `bun@1.3.14`.
  - `.github/workflows/release-please.yml`: pin `oven-sh/setup-bun` `bun-version` to `1.3.14` (was `latest`).

<sup>Written for commit 65f0e611cc40a35e460a389eb2bc71452d15ad58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

